### PR TITLE
Update DiochanChanPerformer.java

### DIFF
--- a/src/com/mishiranu/dashchan/chan/diochan/DiochanChanPerformer.java
+++ b/src/com/mishiranu/dashchan/chan/diochan/DiochanChanPerformer.java
@@ -179,6 +179,7 @@ public class DiochanChanPerformer extends ChanPerformer
 		entity.add("postpassword", data.password);
 		entity.add("gotothread", "on");
 		entity.add("embed", ""); // Otherwise there will be a "Please enter an embed ID" error
+		entity.add("quote", "1"); // Otherwise there will be an "Invalid Server Response" error on /b/
 		if (data.attachments != null)
 		{
 			for (SendPostData.Attachment attachment : data.attachments)


### PR DESCRIPTION
### Fix for posting on /b/

The field "quote" in the request body is mandatory for posting on /b/: otherwise posting will fail and the user will get an "Invalid Server Response" error.
Other boards do not require this field and automatically assume "quote" is set to 0, causing all quotes to other users in a sent message to be considered as greentext. This can be easily tested by posting a message on a board that is not /b/ and quoting someone.
This behavior ("quote": "0") is useless and the front-end does not provide the option to disable quotes.
So the value should always be set to "1".