### PR TITLE
Fixed passcodes (PATTERN_AUTH_MESSAGE) for 4chan.org

### DIFF
--- a/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
+++ b/src/com/mishiranu/dashchan/chan/fourchan/FourchanChanPerformer.java
@@ -247,7 +247,7 @@ public class FourchanChanPerformer extends ChanPerformer {
 		return message;
 	}
 
-	private static final Pattern PATTERN_AUTH_MESSAGE = Pattern.compile("<span.*?>(.*?)<(?:br|/span)>");
+	private static final Pattern PATTERN_AUTH_MESSAGE = Pattern.compile("<h2.*?>(.*?)<(?:br|/h2)>");
 
 	@Override
 	public CheckAuthorizationResult onCheckAuthorization(CheckAuthorizationData data) throws HttpException,


### PR DESCRIPTION
Passcode feature does not work anymore on 4chan.org.

That's because now 4chan responds with `<h2 class="msg-success">Success! Your device is now authorized.</h2>` instead of `<span ...>Success! Your device is now authorized.</span>` which is cannot be parsed by old regexp `PATTERN_AUTH_MESSAGE`.

I've fixed the regexp to `<h2.*?>(.*?)<(?:br|/h2)>`