### PR TITLE
Картинки не работают на синче

### DIFF
--- a/src/com/mishiranu/dashchan/chan/synch/SynchChanConfiguration.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchChanConfiguration.java
@@ -25,9 +25,12 @@ public class SynchChanConfiguration extends ChanConfiguration {
 		posting.allowEmail = true;
 		posting.allowSubject = true;
 		posting.optionSage = true;
+		posting.allowTripcode = true;
 		posting.attachmentCount = 1;
 		posting.attachmentMimeTypes.add("image/*");
-		posting.attachmentMimeTypes.add("video/webm");
+		posting.attachmentMimeTypes.add("video/*");
+		posting.attachmentMimeTypes.add("audio/*");
+		posting.attachmentMimeTypes.add("application/*");
 		posting.attachmentSpoiler = true;
 		return posting;
 	}

--- a/src/com/mishiranu/dashchan/chan/synch/SynchChanLocator.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchChanLocator.java
@@ -12,7 +12,7 @@ public class SynchChanLocator extends ChanLocator {
 	private static final Pattern THREAD_PATH = Pattern.compile("/\\w+/res/(\\d+)\\.html");
 	private static final Pattern ATTACHMENT_PATH = Pattern.compile("/src/\\d+/\\d+/\\d+/\\w+\\.\\w+");
 
-	private static final String HOST_CDN = "cdn.syn-ch.com";
+	private static final String HOST_CDN = "cdn.syn-ch.org";
 
 	public SynchChanLocator() {
 		addChanHost("syn-ch.com");
@@ -22,7 +22,7 @@ public class SynchChanLocator extends ChanLocator {
 		addConvertableChanHost("syn-ch.ru");
 		addSpecialChanHost(HOST_CDN);
 		addSpecialChanHost("cdn.syn-ch.com.ua");
-		addSpecialChanHost("cdn.syn-ch.org");
+		addSpecialChanHost("cdn.syn-ch.com");
 		setHttpsMode(HttpsMode.CONFIGURABLE);
 	}
 

--- a/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
@@ -23,6 +23,7 @@ public class SynchChanMarkup extends ChanMarkup {
 		addTag("span", "style", "text-decoration: underline", TAG_UNDERLINE);
 		addTag("span", "style", "text-decoration: line-through", TAG_STRIKE);
 		addPreformatted("code", true);
+		addColorable("font");
 	}
 
 	@Override

--- a/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
@@ -25,6 +25,7 @@ public class SynchChanMarkup extends ChanMarkup {
 		addPreformatted("code", true);
 		addColorable("font");
 		addColorable("span");
+		addColorable("div");
 	}
 
 	@Override

--- a/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchChanMarkup.java
@@ -24,6 +24,7 @@ public class SynchChanMarkup extends ChanMarkup {
 		addTag("span", "style", "text-decoration: line-through", TAG_STRIKE);
 		addPreformatted("code", true);
 		addColorable("font");
+		addColorable("span");
 	}
 
 	@Override

--- a/src/com/mishiranu/dashchan/chan/synch/SynchModelMapper.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchModelMapper.java
@@ -103,6 +103,7 @@ public class SynchModelMapper {
 			// Vichan JSON API bug, sometimes comment is broken
 			com = com.replace("<a  ", "<a ").replaceAll("href=\"\\?", "href=\"");
 			com = com.replace("class=\"public_ban\"", "style=\"color: red\"");
+			com = com.replace("class=\"irony\"", "style=\"color: #FF00FF\"");
 			post.setComment(com);
 		}
 		ArrayList<Attachment> attachments = null;

--- a/src/com/mishiranu/dashchan/chan/synch/SynchModelMapper.java
+++ b/src/com/mishiranu/dashchan/chan/synch/SynchModelMapper.java
@@ -102,6 +102,7 @@ public class SynchModelMapper {
 		if (com != null) {
 			// Vichan JSON API bug, sometimes comment is broken
 			com = com.replace("<a  ", "<a ").replaceAll("href=\"\\?", "href=\"");
+			com = com.replace("class=\"public_ban\"", "style=\"color: red\"");
 			post.setComment(com);
 		}
 		ArrayList<Attachment> attachments = null;


### PR DESCRIPTION
Поставил в настройки>форумы>синч>домен .org, но картинки всё равно грузиться пытались с cdn на .com, который то ли дохлый, то ли забанен, думаю лучше поставить по-дефолту .org, чтобы из РФ не надо было пользоваться vpn
Или как-то сделать, чтобы cdn от домена выбранного зависил
И ещё на синче уже работают трипкоды и типов файлов поддерживается больше